### PR TITLE
Add link to Batch Working Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Create a [github issue](https://github.com/cncf/tag-runtime/issues/new) for an e
 
 * [Container Orchestrated Device Working Group](https://github.com/cncf/tag-runtime/blob/master/wg/COD.md)
 * [IoT Edge Working Group](https://github.com/cncf/tag-runtime/blob/master/wg/iot-edge.md)
+* [Batch Working Group](https://github.com/cncf/tag-runtime/blob/master/wg/bsi.md)
 
 ## Related groups
 

--- a/wg/bsi.md
+++ b/wg/bsi.md
@@ -62,7 +62,8 @@ by the TOC unless otherwise stated here.
 
 ## Communities
 
-- Meeting Schedule: Twice a month on the 1st and 3rd Thu at 
+- Meeting Schedule: Twice a month on the 1st and 3rd Thu at 8am PDT/PST
+- [Meeting Invite](https://calendar.google.com/event?action=TEMPLATE&tmeid=aTBka2F2aWt2ZTM0aTZuaG40MXRhdH[…]UwMDAwWiBhbGV4QGdyLW9zcy5pbw&tmsrc=alex%40gr-oss.io&scp=ALL)
 - Mailing list: cncf-tag-runtime@lists.cncf.io 
 - Slack channel:  https://cloud-native.slack.com/archives/C02Q5DFF3MM 
 


### PR DESCRIPTION
Two additions:
* Adding a link to the batch working group on the tag-runtime README
* Adding the date and time and a meeting invite link to the bsi.md