### PR TITLE
Add working group information to website

### DIFF
--- a/website/content/wgs/COD.md
+++ b/website/content/wgs/COD.md
@@ -1,0 +1,90 @@
+# Container Orchestrated Device Working Group Charter
+
+COD, the Container Orchestrated Device Working Group, is a small group formed by passionate Container Runtime Maintainers and Device Vendors looking to solve many of the challenges Devices face in the cloud native space.
+ 
+* In today’s cloud native space, the support for Third Party Devices such as FPGAs, GPUs and others is fragmented, uneven and inconsistent. For example:
+* Kubernetes supports Device Plugins
+* Nomad has its own concept of Device Plugins
+* Docker has an in tree plugin mechanism
+* Podman has a concept of hooks 
+* LXC has its own concept of hooks
+* ...
+ 
+From a user's perspective, the support for devices is widely different from one runtime to another and often requires painful setup and configuration.
+Users also face the fact that container orchestrators also implement plugins for devices, leading to a different deployment story and level of support than they have at the runtime level.
+ 
+From a vendor’s perspective, each plugin mechanism has a different set of capabilities leading plugin authors to either have to re-implement their plugins (leading to maintainability hell), resort to hacks or simply not support runtimes they should easily be able to support (e.g: Podman support but no Docker support).
+
+## Goal
+
+The Container Orchestrated Workging Group aims to improve the support of Devices in the cloud native space. 
+
+## Projects
+ 
+### [Container Device Interface](https://github.com/cncf-tags/container-device-interface)
+ 
+The Container Device Interface (CDI) is the first project the group focuses on and is a specification, for container runtimes, to support third party devices through a commonly understood plugin system (based on the CNI model).
+ 
+#### Concrete Deliverables
+The main deliverable for CDI is a specification that runtimes can implement to enable containers to become device aware.
+A secondary deliverable is a golang interface, with a package that can be re-used to merge the specification as well as a validation schema.
+ 
+#### Target User Stories
+
+(Consistent UX) As a user, my experience across runtimes should be fairly consistent
+(Standard Interface) As a plugin author, I should be focusing on my plugin’s features not adding support for similar runtimes
+(Simple Model) As a cluster or system administrator, my experience installing plugins should be simple (e.g: run a container, install a package, deploy a pod, …)
+(Ease of Deployment) Solve the difficulties faced by users in the cloud-native space
+(Consistency) As a user, my experience interacting with runtimes should be fairly consistent
+ 
+#### Slides
+
+[Container Device Interface Slides](https://docs.google.com/presentation/d/1UXgKYx5AA9ThYYLDswHsXFDL7TrNzVcac8zjlMIfEDs/)
+
+
+## General Information
+
+## Stakeholder TAG
+
+- TAG Runtime
+
+## Meetings
+
+* Every other Tuesday at 7am PST. [Convert to your timezone](http://www.thetimezoneconverter.com/?t=07:00&tz=PT%20%28Pacific%20Time%29).
+* Link to [Google Doc Notes](https://docs.google.com/document/d/1gUgAMEThkRt4RJ7pA7ZbPPmIOX2Vb7fwH025MjfcTYU/edit?ts=5ef21262#)
+
+
+## WG Chairs
+
+* Alexander Kanevskiy ([@kad](https://gihub.com/kad)), Intel
+* Evan Lezar ([@elezar](https://github.com/elezar)), NVIDIA
+
+## WG Members
+
+* Urvashi Mohnani ([@umohnani8](https://gihub.com/umohnani8)) 
+* Ed Bartosh
+* Ukri Niemimuukko
+* Marek Counts 
+* Mike Brown, IBM
+* Mrunal Patel
+* Kevin Klues ([@klueska](https://gihub.com/klueska)), NVIDIA
+
+## WG Emeretus chair
+
+* Renaud Gaubert ([@RenaudWasTaken](https://github.com/RenaudWasTaken)), NVIDIA
+
+## Slack
+
+#tag-runtime
+
+## Mailing List
+
+https://lists.cncf.io/g/cncf-tag-runtime
+
+# Related Information
+ 
+* [Container Device Interface Slides](https://docs.google.com/presentation/d/1UXgKYx5AA9ThYYLDswHsXFDL7TrNzVcac8zjlMIfEDs/)
+* Networking Plumbing Working Group - NPWG
+  * https://docs.google.com/document/d/1oE93V3SgOGWJ4O1zeD1UmpeToa0ZiiO6LqRAmZBPFWM
+  * https://docs.google.com/document/d/1rBm-L1ymXIjoKNA6w2lixwBAjt9-tnbs-ee7AcLRbVE
+  * https://docs.openstack.org/kuryr-kubernetes/latest/specs/rocky/npwg_spec_support.html

--- a/website/content/wgs/_index.md
+++ b/website/content/wgs/_index.md
@@ -1,0 +1,16 @@
+---
+title: Working Groups
+toc_hide: false
+menu:
+  main:
+    weight: 40
+---
+
+More information about the various TAG Runtime working groups can be found
+here:
+
+- [Batch System Initiative Working Group](batch.md)
+- [Container Orchestrated Device Working Group](COD.md)
+- [IoT Edge Working Group](iot.md)
+- [Special Purpose Operating System Working Group](spos.md)
+- [WebAssembly Working Group](wasm.md)

--- a/website/content/wgs/batch.md
+++ b/website/content/wgs/batch.md
@@ -1,0 +1,68 @@
+# Cloud Native Batch System Initiative Working Group Charter
+ 
+## Introduction
+
+Cloud Native Batch System Initiative Working Group is a group formed by 
+passionate batch system maintainers looking to support batch workload in cloud native environments.
+ 
+## Background
+
+Currently, more and more users would like to migrate batch workloads to cloud native environments,
+and multiple existing solutions from different community projects currently address this requirement,
+e.g. Volcano, YuniKorn, Armada, MCAD, which makes it easy for users to migrate.
+But from a user perspective, the current support for batch workloads is widely different from 
+one batch system to another and requires a comprehensive migration between them. 
+It’s necessary to build a specification for batch workloads in the cloud native ecosystem, 
+and help related projects figure out their scopes and interaction. The users and communities can 
+follow this specification to work with projects in CNCF, e.g. Kubernetes, Volcano, Armada, 
+or even out of CNCF, e.g. YuniKorn and MCAD and others.
+  
+## Goal:
+
+The Cloud Native Batch System Initiative Working Group aims to define
+batch system specifications in the cloud native ecosystem for different batch projects,
+and related CRDs, gRPC, client libraries for projects. Those outputs will help related projects
+to figure out their scopes, and identify the different scenarios for different projects, e.g. traditional HPC vs. HPC on Cloud.
+   
+## In Scope:
+
+Batch system specifications, including:
+
+- Job/ArrayJob/CronJob
+- Job Flow/Job Dependency/Job Orchestration
+- Queue
+- SchedulingPolicy (e.g. PodGroup)
+- Command Line & Script
+- Multi-Cluster Scheduling
+- Best Practices
+
+## Out Of Scope:
+
+- Non-batch related workloads
+- The implementation of the batch system
+
+## Related Communities
+
+This Working Group will be reaching out and requesting/receiving feedback from other communities and working groups on a regular basis (not limited to):
+
+- [Volcano](https://volcano.sh/)
+- [Kubernetes](https://kubernetes.io/)
+- [YuniKorn](https://yunikorn.apache.org/)
+- [Kubernetes WG Batch](https://github.com/kubernetes/community/blob/master/wg-batch/charter.md)
+- Etc.
+
+## Operations
+
+This Batch System Initiative Working Group follows the [standard operating guidelines](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#operating-model) provided
+by the TOC unless otherwise stated here.
+
+- TOC Liaisons: Ricardo Rocha (ricardo.rocha@cern.ch)
+- SIG Chairs: Klaus Ma (klaus1982.cn@gmail.com), Weiwei Yang (abvclouds@gmail.com), Alex Scammon (alex@gr-oss.io)
+
+## Communities
+
+- Meeting Schedule: Twice a month on the 1st and 3rd Thu at 8am PDT/PST
+- [Meeting Invite](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=aTBka2F2aWt2ZTM0aTZuaG40MXRhdHM2dHNfMjAyMzA5MTFUMTUwMDAwWiBjXzY1MjRkNjA2OWI0YjczZDY1NGE2ZGFkYmFjNmQzMWRhMmU3NzZkOWNhMGRkZGY4OGFiMTJlMjZiODc1NzBhODJAZw&tmsrc=c_6524d6069b4b73d654a6dadbac6d31da2e776d9ca0dddf88ab12e26b87570a82%40group.calendar.google.com&scp=ALL)
+- Mailing list: cncf-tag-runtime@lists.cncf.io 
+- Slack channel:  https://cloud-native.slack.com/archives/C02Q5DFF3MM 
+

--- a/website/content/wgs/iot.md
+++ b/website/content/wgs/iot.md
@@ -1,0 +1,61 @@
+# IoT Edge Working Group Charter
+
+## Mission Statement
+
+IoT Edge Working group focuses on topics of running workloads in edge computing environments and providing support for connecting far-edge devices. Evolving from the Kubernetes IoT Edge working group, it extends the mission to include a wider set of projects. Working group's mission is to enable widespread and successful use of cloud-native technologies for IoT and Edge computing use cases. It will engage in the following activities:
+
+- **Educate and inform** users with unbiased information regarding edge computing related CNCF projects
+- **Strengthen the ecosystem** by fostering better collaboration between existing projects
+- **Curate best practices** related to the edge computing systems that are effective and actionable.
+- Identify gaps in the landscape and **attract new projects** to the ecosystem.
+- **Provide technical support** to users trying to implement edge computing systems
+
+## Scope
+The working group is interested in all topics related to building edge computing solutions, including:
+
+- Developing and adjusting **infrastructure for edge deployments**. As an extension to the cloud, edge computing infrastructure needs modifications to meet edge conditions. Resource constraints and intermittent network connectivity are commonly considered topics in Edge computing.
+- Development and configuration of **edge-specific workloads**. How do we write and deploy our workloads to edge environments? Topics like multi-architecture builds, multi-cluster deployments, access to system resources and GitOps are usually discussed in this regard.
+- Cloud-native **DevOps practices for edge** environments. How do we operate our workloads in edge deployment scenarios? Typical DevOps and Observability topics need to be adjusted to edge computing environments.
+
+## Deliverables
+The working group will build collaboration, knowledge, and projects in the edge computing space, including:
+
+- **Publications, presentations and whitepapers** on interesting topics - the group will try to stay ahead of the current technology trends and provide material on the latest innovative topics in the space.
+- **Example architectures and demos** - provide well documented use cases using existing projects and demos that can be used as starting point of future projects.
+- **Standards, tests and certifications** - the group will investigate if it is possible to certify solutions in well defined domains against known criteriums.
+- **Metrics** - provide guidelines for project planning in terms of resource usage.
+- **Ecosystem updates** - give updates about the landscape of cloud native projects on the edge at conferences, in publications, and to the Runtime TAG.
+
+## Current CNCF Edge-centric projects
+The following is a list of well-known CNCF projects used in edge-computing solutions:
+
+- Kubernetes
+- KubeEdge
+- Akri
+- K3s
+- WasmEdge
+
+The list is not exhaustive. Please submit a PR to add your edge-focused CNCF project or reach out to the [#wg-iot-edge](https://kubernetes.slack.com/messages/wg-iot-edge) channel on Kubernetes Slack.
+
+## Operations
+This WORKING GROUP follows the [standard operating guidelines](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#operating-model) provided
+by the TOC unless otherwise stated here.
+
+### TAG Liaison
+- [Ricardo Aravena](https://github.com/raravena80), TruEra 
+
+### TOC Liaisons
+- [Richard Hartmann](https://github.com/RichiH), Grafana Labs
+- [Ricardo Rocha](https://github.com/rochaporto), CERN
+- [Davanum Srinivas](https://github.com/dims), VMware
+
+### Chairs
+- [Kate Goldenring](https://github.com/kate-goldenring), Microsoft
+- [Steve Wong](https://github.com/cantbewong), VMware
+- [Dejan Bosanac](https://github.com/dejanb), Red Hat
+
+## Communication
+- Community Meeting (Pacific Time): [Wednesdays at 09:00 PT](https://zoom.us/j/92778512626?pwd=MXhlemwvYnhkQmkxeXllQ0Z5VGs4Zz09) (every two weeks). [Convert to your timezone](http://www.thetimezoneconverter.com/?t=09:00&tz=PT).
+  - [Meeting notes and Agenda](https://docs.google.com/document/d/1Yuwy9IO4X6XKq2wLW0pVZn5yHQxlyK7wdYBZBXRWiKI/edit?usp=sharing).
+- Kubernetes Slack: [#wg-iot-edge](https://kubernetes.slack.com/messages/wg-iot-edge)
+- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-iot-edge)

--- a/website/content/wgs/spos.md
+++ b/website/content/wgs/spos.md
@@ -1,0 +1,86 @@
+ # Special Purpose Operating System Working Group Charter
+ 
+ ## Background
+
+Special Purpose Operating Systems are designed to run well defined workloads with minimal boilerplate of dependencies suited for niche use cases. 
+
+In the cloud native world, these workloads include containers, however, they can be extended to other special purpose workloads such as WASM, etc. 
+
+## Mission Statement
+
+The special purpose operating system working group (wg-sp-os) focuses on the operations, best practices and guidance on running cloud native workloads on operating systems, including, but not limited to containers, across orchestrators such as Kubernetes and other cloud-native projects. The immediate focus of the working group will be to work on container OSs, however, other areas such as WASM would still be part of the charter of the working group. For future cloud native related efforts, the charter of the working group would be extended upon consensus in the community. The working group aims to:
+- Foster an ecosystem for collaboration between existing projects
+- Educate users with unbiased and common understanding of special purpose OSs
+- Identify gaps in the landscape and attract new projects to the ecosystem
+
+## Scope
+
+The working group is focused on the following areas:
+Guidance on Cloud Native practices for Container OSs which include:
+- Lifecycle and configuration management
+- Resource utilization
+- Upgrade scenarios
+- Long Term Support constraints
+- Compatibility with container runtimes
+- Flexibility and interoperability with container orchestration solutions which includes Compatibility with kubelet API versus host dbus/systemd in the case of Kubernetes workloads
+- Best practices for security considerations for cloud native container os workloads
+- Best practices for integration with softwares designed for management and monitoring of the hosts, such as antivirus agents. 
+
+## Deliverables 
+
+- Publications, presentations, and whitepapers on areas related to running cloud native workloads on special purpose OSs
+   - Potential whitepaper ideas:
+      - Guidance on LTS: How does LTS in Kubernetes impact special purpose/container OSs?
+      - What is a container operating system for cloud native workloads?
+- Integration with the Kubernetes project
+   - Exploring the area of providing an interface for OS in Kubelet, similar to CNI or CSI. A single interface to work with Kubelet to work across distributions.
+- Guidance on usage and technical support for running container workloads on OSs
+- Exploration and looking beyond the horizon of container workloads and incorporating other workloads such as WASM on special purpose OSs with close collaboration with WASM Working Group.
+- Collaboration within the community on related areas like edge computing, etc
+- Collaboration for any fixes or contributions to upstream projects like the Linux kernel
+- Integration with other projects in the community like Cluster API
+   - Exploring the area for a standard abstraction for special purpose OSs to interact with Cluster API, with respect to bootstrap providers, etc.
+- Metrics - provides guidelines for project planning in terms of resource usage.
+- Ecosystem updates - provides updates on the landscape of cloud-native projects on the special purpose OSs at conferences, in publications, and to the TAG Runtime.
+
+## Open Source Projects
+
+Following is a list of popular open-source projects that are in the container OS space:
+- [Bottlerocket](https://bottlerocket.dev)
+- [Flatcar](https://www.flatcar.org)
+- [Talos](https://www.talos.dev)
+- [Kairos](https://kairos.io)
+- [openSUSE MicroOS](https://microos.opensuse.org/)
+- [Google’s Container Optimized OS (COS)](https://cloud.google.com/container-optimized-os/docs/resources/sources)
+
+## Operations
+This WORKING GROUP follows the [standard operating guidelines](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#operating-model) provided by the TOC unless otherwise stated here.
+
+## TAG Liaison
+- [Rajas Kakodkar](https://github.com/rajaskakodkar)
+
+## TOC Liaison
+- [Nikhita Raghunath](https://github.com/nikhita)
+
+## Chairs
+- [Danielle Tal](https://github.com/miao0miao)
+- [Sean McGinnis](https://github.com/stmcginnis)
+
+## Technical Leaders
+- [Thilo Fromm](https://github.com/t-lo)
+
+## Communication
+
+- **Community Meeting:** Biweekly, 1st and 3rd Thursday of the Month at 2:00 PM UTC [(convert to your timezone)](https://dateful.com/convert/coordinated-universal-time-utc?t=2pm)
+- **Zoom Link for the meeting:**  [Click here](https://zoom.us/my/cncftagruntime?pwd=N2xyRkZaN2JWZkNmS3EzbE1HVnhEQT09) , Passcode: 77777
+- **Meeting Notes and Agenda:** [Click here](https://docs.google.com/document/d/1MeFwrnOeleTazqmZe16p0fEFLiLPgtCIAAOFIatWNsg/)
+- **CNCF Slack:** [#wg-sp-os](https://communityinviter.com/apps/cloud-native/cncf)
+- **Mailing list:** https://lists.cncf.io/g/cncf-tag-runtime
+
+## Document Reviewed and Contributed by
+- [Ettore Di Giacinto](https://github.com/mudler)
+- [Justin Haynes](https://github.com/jhaynes)
+- [Nikhita Raghunath](https://github.com/nikhita)
+- [Priyanka Saggu](https://github.com/Priyankasaggu11929)
+- [Rajas Kakodkar](https://github.com/rajaskakodkar)
+- [Sean McGinnis](https://github.com/stmcginnis)

--- a/website/content/wgs/wasm.md
+++ b/website/content/wgs/wasm.md
@@ -1,0 +1,123 @@
+# WebAssembly (Wasm) Working Group Charter
+
+## Background
+
+WebAssembly, commonly known as Wasm, refers to a compact binary instruction format utilized by a stack-based virtual machine. Its primary purpose is to serve as a versatile compilation target for programming languages, enabling seamless deployment of applications for both client-side and server-side environments.
+
+In the context of cloud native, and with the presence of a Wasm runtime, the portability and versatility of Wasm allow users to run workloads in a diverse set of environments in both a centralized location and at the edge, including but not limited to VMs running a single docker daemon, Kubernetes cluster, and any other compatible workload orchestrator.
+
+## Mission Statement
+
+The Wasm working group focuses on topics of running Wasm workloads across the edge, Kubernetes, and other cloud-native projects. The primary mission is to enable Wasm to be a first-class alternative to running such workloads. The secondary mission is to ensure Wasm is integrated and evolved across all cloud-native projects. We do so by promoting the adoption and usage of WebAssembly by providing resources, best practices, and tools that enable end users to utilize its unique benefits.
+
+## Scope
+
+The working group is interested in all topics related to building Wasm artifacts, packaging and distribution, and developing solutions that embrace Wasm, including:
+
+- Developing and adjusting **infrastructure for Wasm deployments**. The cloud-native modifications to meet Wasm conditions. 
+- Development and configuration of **wasm-specific workloads**. How do we start working with Wasm? How do we write,  deploy, test and debug our workloads to Wasm environments? How do we empower Wasm to those specific ML/AI workloads with a wide variety of AI HW accelerators? 
+- Cloud-native **DevOps practices for Wasm** environments. How do we operate our workloads in Wasm deployment scenarios? Typical DevOps and Observability topics need to be adjusted to Wasm environments.
+- **Interoperability** with other deployment types. Wasm workloads should be able to run in a pod alongside containers seamlessly.
+- **Security** - Understanding, documenting, and educating folks on the security considerations of their WASM and WASI workloads and how to integrate WASM runtimes into their projects safely.
+- **Wasm artifacts** - guide and document container registry storage structures to provide a basis for compatibility for container runtimes.
+
+## Deliverables
+
+The working group will build collaboration, knowledge, and projects in the Wasm space, including:
+ 			
+- **Publications, presentations, and whitepapers** on interesting topics - the group will stay ahead of the current technology trends and provide material on the latest innovative topics in the space.
+- **Example architectures and demos** - provides well-documented use cases using existing projects and demos that can be used as starting points for future projects.
+- **Standards, tests, and certifications** - the working group will investigate if it is possible to certify solutions in well-defined domains against known criteria.
+- **WebAssembly ecosystem proposals** - provide updates on the different open proposals and how they benefit the ecosystem. Collaborate and align with the community on the current and new proposals. 
+- **Metrics** - provides guidelines for project planning in terms of resource usage.
+- **Ecosystem updates** - provides updates on the landscape of cloud-native projects on the Wasm at conferences, in publications, and to the Runtime TAG.
+- **Vertical Use cases** - provide documentation or code implementation of cloud-native wasm use cases in certain vertical scenarios (network, database, AI, embedding a Wasm runtime, etc.)
+
+## Projects
+
+### Current CNCF Wasm-centric projects
+
+The following is a list of well-known CNCF projects built by or integrates with Wasm:
+
+- **Runtime related**
+
+    - [WasmEdge](https://wasmedge.org/)
+    - [WasmCloud](https://github.com/wasmcloud/)
+    - [Runwasi](https://github.com/containerd/runwasi)
+    - [Krustlet](https://github.com/krustlet/krustlet)
+    - [Kuasar](https://github.com/kuasar-io/kuasar) - Kubernetes Container Runtime Engine supports Wasm
+    - [Dapr](https://dapr.io) - both embedded Wasm in sidecar runtime as well as Wasm SDK to access the sidecar service from Wasm apps. 
+    - [crun](https://github.com/containers/crun)
+    - [youki](https://github.com/containers/youki)
+    - [Docker](https://docs.docker.com/desktop/wasm/)
+
+- **Other CNCF scopes**
+
+    - [Open Policy Agent](https://github.com/open-policy-agent/opa) - can compile policies to wasm files
+    - [Envoy](https://github.com/envoyproxy/envoy)/[Istio](https://github.com/istio/istio) (Wasm filter)
+    - [KubeWarden](https://github.com/kubewarden) - Kubernetes policy engine; policies compiled to WebAssembly
+    - [Knative](https://knative.dev/docs/)
+    - [KubeEdge](https://kubeedge.io/en/)
+    - [OpenFunction](https://openfunction.dev)
+    - [SuperEdge](https://superedge.io)
+
+Note that even though this group is under TAG-Runtime, there may be other areas to interface as indicated above.
+
+### Open Source (non-CNCF) Wasm Projects
+
+A list of notable, popular, and/or influential open-source Wasm projects that are in the cloud native space but not necessarily officially part of the CNCF (Runtime and non-runtime related):
+
+- [Wasmer](https://wasmer.io/)
+- [Suborbital](https://suborbital.dev/)
+- [Spin](https://github.com/fermyon/spin)
+- [Wazero](https://wazero.io/)
+- [extism](https://extism.org)
+- [wasmtime](https://wasmtime.dev)
+- [WasmLabs](https://wasmlabs.dev) at VMWare
+- [Javy](https://github.com/bytecodealliance/javy)
+- [SpiderLightning (Slight)](https://github.com/deislabs/spiderlightning)
+
+## Operations
+
+This WORKING GROUP follows the [standard operating guidelines](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#operating-model) provided by the TOC unless otherwise stated here.
+
+### TAG Liaison
+- [Ricardo Aravena](https://github.com/raravena80)
+- [Heba Elayoty](https://github.com/helayoty)
+
+### TOC Liaison
+- [Nikhita Raghunath](https://github.com/nikhita)
+
+### WG Chairs
+- [David Justice](https://github.com/devigned)
+- [Danielle Lancashire](https://github.com/endocrimes)
+
+
+### WG Technical Leaders
+- [Angel M Miguel](https://github.com/Angelmmiguel)
+- [Kevin Hoffman](https://github.com/autodidaddict)
+- [Sven Pfennig](https://github.com/0xE282B0)
+
+## Communication
+
+- **Community Meeting** (Pacific Time): Weekly, Tuesdays at 5:00 pm CEST - [details](https://tockify.com/cncf.public.events/detail/609/1687273200000?search=wasm) -
+- **Meeting Notes and Agenda**: [Click here](https://docs.google.com/document/d/1d6PvdCuKbSdcuXG2M9fBSDQPTPfHYA0PPDTM2plbH3I/edit#heading=h.cthb8ncah3pb)
+- **CNCF Slack**: [#wg-wasm](https://cloud-native.slack.com/archives/C056EDRH4PJ)
+- **Mailing list**: https://lists.cncf.io/g/cncf-tag-runtime 
+
+### Charter Reviewed and Contributed by
+- [Angel M Miguel](https://github.com/Angelmmiguel)
+- [Danielle Lancashire](https://github.com/endocrimes)
+- [David Justice](https://github.com/devigned)
+- [Heba Elayoty](https://github.com/helayoty)
+- [Ismo Puustinen](https://github.com/ipuustin)
+- [Jiaxiao (Joe) Zhou](https://github.com/Mossaka)
+- [Michael Yuan](https://github.com/juntao)
+- [Mikkel Mork](https://github.com/mikkelhegn)
+- [Ralph Squillace](https://github.com/squillace)
+- [Ravikanth Chaganti](https://github.com/rchaganti)
+- [Ricardo Aravena](https://github.com/raravena80)
+- [Toru Komatsu](https://github.com/utam0k)
+- [Tiejun Chen](https://github.com/TiejunChina)
+- [Shivay Lamba](https://github.com/shivaylamba)
+- [Sven Pfennig](https://github.com/0xE282B0)


### PR DESCRIPTION
This adds the charter and working group details to the published website.

Related: #61 

It is less than ideal at this point since it is duplicating the content from the `wg` folder in order to make it available for hugo rendering. The current tools like `readFile` from the docsy template does not allow pulling in files from outside the website directory.

Until we can find a workaround for that, this just copies the content. Once we find a better way, we should be able to keep the working group charters as the single source of truth and just pull it in to the rendered content. But for now, this makes a nice rendered view of our working groups to make it easier for folks to find and learn about the various working groups in TAG Runtime.