### PR TITLE
Fix Slack hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example CNCF projects within the scope of TAG-Runtime
 Anyone is welcome to join our open discussions of TAG-Runtime projects and share news about the group's objectives. We also encourage project teams to share progress updates or post questions on these channels:
 
 * [Email list](https://lists.cncf.io/g/cncf-tag-runtime)
-* [CNCF Slack Channel]([https://slack.cncf.io/](https://cloud-native.slack.com/archives/CPBE97SMU))
+* [#tag-runtime](https://cloud-native.slack.com/archives//CPBE97SMU) on [CNCF Slack](https://slack.cncf.io/)
 
 ## Meeting times
 


### PR DESCRIPTION
I notice the Slack hyperlink was not resolving as there was incorrect markdown punctuation in the link.
Added a little extra detail