### PR TITLE
add Taylor Thomas as wg wasm chair

### DIFF
--- a/wg/wasm.md
+++ b/wg/wasm.md
@@ -91,6 +91,7 @@ This WORKING GROUP follows the [standard operating guidelines](https://github.co
 ### WG Chairs
 - [David Justice](https://github.com/devigned)
 - [Danielle Lancashire](https://github.com/endocrimes)
+- [Taylor Thomas](https://github.com/thomastaylor312)
 
 
 ### WG Technical Leaders


### PR DESCRIPTION
In light of the work that Taylor Thomas has been leading the Wasm Working Group and his contributions to the broader community in Wasm and Kuberentes, we would like to add Taylor as a chair for the WG.