### PR TITLE
Installs GTM instead of just GA4

### DIFF
--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -4,6 +4,9 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}">
+    {{ if hugo.IsProduction }}
+      {{ partial "gtm-noscript.html" . }}
+    {{ end }}
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/website/layouts/blog/baseof.html
+++ b/website/layouts/blog/baseof.html
@@ -4,6 +4,10 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}">
+    {{ if hugo.IsProduction }}
+      {{ partial "gtm-noscript.html" . }}
+    {{ end }}
+
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/website/layouts/partials/gtm-noscript.html
+++ b/website/layouts/partials/gtm-noscript.html
@@ -1,0 +1,5 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WJJ7VKZ"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+  

--- a/website/layouts/partials/head.html
+++ b/website/layouts/partials/head.html
@@ -18,15 +18,13 @@
 <script src="https://cmp.osano.com/16A0DbT9yDNIaQkvZ/c3494b1e-ff3a-436f-978d-842e9a0bed27/osano.js"></script>
 
 {{ if hugo.IsProduction }}
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-T6VMPWFRDW"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-T6VMPWFRDW');
-</script>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-WJJ7VKZ');</script>
+  <!-- End Google Tag Manager -->
 
 {{ end }}
 {{ partialCached "head-css.html" . "asdf" }}


### PR DESCRIPTION
To allow us more flexibility we want to install GTM in place of just GA4. We will also be including a HubSpot tracking code using GTM. See https://github.com/cncf/cncf.io/issues/823