### PR TITLE
Remove edit link for pages that are symlinked

### DIFF
--- a/website/layouts/partials/page-meta-links.html
+++ b/website/layouts/partials/page-meta-links.html
@@ -1,8 +1,8 @@
 {{ $path := "" }}
 {{ with .File }}
-  {{ $path = .Path }}
+  {{ $path = printf "%s/%s" .Lang .Path }}
 {{ else }}
-  {{ $path = .Path }}
+  {{ $path = printf "%s/%s" .Lang .Path }}
 {{ end }}
 {{ $pathFormatted := replace $path "\\" "/" }}
 {{- $prefix := index (split $path "/") 0 -}}

--- a/website/layouts/partials/page-meta-links.html
+++ b/website/layouts/partials/page-meta-links.html
@@ -1,8 +1,8 @@
 {{ $path := "" }}
 {{ with .File }}
-  {{ $path = printf "%s/%s" .Lang .Path }}
+  {{ $path = .Path }}
 {{ else }}
-  {{ $path = printf "%s/%s" .Lang .Path }}
+  {{ $path = .Path }}
 {{ end }}
 {{ $pathFormatted := replace $path "\\" "/" }}
 {{- $prefix := index (split $path "/") 0 -}}
@@ -26,7 +26,10 @@
 {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
 {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
 
+{{ if not (in $pathFormatted "wgs") }}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+{{ end }}
+
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 {{ if $gh_project_repo }}
 {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}


### PR DESCRIPTION
The edit link was pointing to the wrong location for pages that are symlinked. The most immediate fix is here, to just remove it for these pages.