### PR TITLE
Fix broken links in wgs/cnaiwg/_index.md

### DIFF
--- a/website/content/en/wgs/cnaiwg/_index.md
+++ b/website/content/en/wgs/cnaiwg/_index.md
@@ -20,4 +20,4 @@ weight: 3
 
 ## Links
 
-* [CNCF Cloud Native AI White Paper](/whitepapers/cloudnativeai/)
+* [CNCF Cloud Native AI White Paper](whitepapers/cloudnativeai/)

--- a/website/content/ja/wgs/cnaiwg/_index.md
+++ b/website/content/ja/wgs/cnaiwg/_index.md
@@ -20,4 +20,4 @@ weight: 3
 
 ## Links
 
-* [CNCF Cloud Native AI White Paper](/whitepapers/cloudnativeai/)
+* [CNCF Cloud Native AI White Paper](whitepapers/cloudnativeai/)


### PR DESCRIPTION
## Change List

- Fix broken links in wgs/cnaiwg/_index.md (en/ja)

## Background

The links in https://tag-runtime.cncf.io/wgs/cnaiwg/#links are broken.