### PR TITLE
Add BSI landscape embed view to BSI page

### DIFF
--- a/website/content/en/wgs/bsi/landscape
+++ b/website/content/en/wgs/bsi/landscape
@@ -1,0 +1,1 @@
+../../../../../wgs/bsi/landscape

--- a/website/layouts/shortcodes/bsi-landscape-embed-view.html
+++ b/website/layouts/shortcodes/bsi-landscape-embed-view.html
@@ -3,7 +3,7 @@
 <div class="pr-5 my-2 flex-grow-1">
 <iframe id="embed-landscape"
         src="https://bsi-landscape.netlify.app/embed/embed.html?key=batch-scheduling&headers=true&category-header=false&category-in-subcategory=false&title-uppercase=true&title-alignment=left&title-font-family=sans-serif&title-font-size=14&style=shadowed&bg-color=%23d62293&fg-color=%23ffffff&item-modal=true&item-name=true&size=lg&items-alignment=left&item-name-font-size=12"
-        height="620"
+        height="744"
         width="100%"
         style="display:block;border:none;">
 </iframe>

--- a/website/layouts/shortcodes/bsi-landscape-embed-view.html
+++ b/website/layouts/shortcodes/bsi-landscape-embed-view.html
@@ -1,0 +1,18 @@
+<!-- Landscape embed view -->
+<small><i><a href="https://bsi-landscape.netlify.app/" target="_blank">View full landscape</a></i></small>
+<div class="pr-5 my-2 flex-grow-1">
+<iframe id="embed-landscape"
+        src="https://bsi-landscape.netlify.app/embed/embed.html?key=batch-scheduling&headers=true&category-header=false&category-in-subcategory=false&title-uppercase=true&title-alignment=left&title-font-family=sans-serif&title-font-size=14&style=shadowed&bg-color=%23d62293&fg-color=%23ffffff&item-modal=true&item-name=true&size=lg&items-alignment=left&item-name-font-size=12"
+        height="620"
+        width="100%"
+        style="display:block;border:none;">
+</iframe>
+</div>
+<!-- Landscape embed item details view -->
+<!-- NOTE: the script and the iframe below should only be added once, even when adding multiple embed views to the page -->
+<script src="https://bsi-landscape.netlify.app/embed/embed-item.js"></script>
+<iframe id="embed-item"
+        src="https://bsi-landscape.netlify.app/embed/embed-item.html"
+        style="width:100%;height:100%;display:block;border:none;position:fixed;top:0;bottom:0;left:0;right:0;z-index:2147483647;display:none;">
+</iframe>
+<!-- End of landscape embed view -->

--- a/wgs/bsi/charter/index.md
+++ b/wgs/bsi/charter/index.md
@@ -1,5 +1,6 @@
 ---
 title: Cloud Native Batch System Initiative Working Group Charter
+weight: 1
 ---
  
 ## Introduction

--- a/wgs/bsi/landscape/index.md
+++ b/wgs/bsi/landscape/index.md
@@ -1,0 +1,9 @@
+---
+title: Cloud Native Batch System Initiative Working Group Landscape
+---
+
+The Cloud Native Batch System Initiative Working Group (BSI) Landscape is a collection of batch systems that are cloud
+native or have cloud native features. The landscape is intended to help users and developers understand the batch
+systems available in the cloud native ecosystem and their features.
+
+{{< bsi-landscape-embed-view >}}


### PR DESCRIPTION
This PR sets up the BSI landscape page, embedding the full landscape from https://bsi-landscape.netlify.app/ (source: https://github.com/naskio/bsi-landscape)

- Added `weight` FrontMatter header to the BSI charter page for sorting.
- Added shortcode for embedding the BSI landscape.
- Created a dedicated BSI landscape page (en only).
- Resized the landscape iframe for optimal display.
