### PR TITLE
Add 'Communications' and 'About' to the main page of the BSI WG

### DIFF
--- a/website/content/en/wgs/bsi/_index.md
+++ b/website/content/en/wgs/bsi/_index.md
@@ -3,3 +3,14 @@ title: Batch System Initiative Working Group
 toc_hide: false
 list_pages: true
 ---
+
+## About
+
+The Cloud Native Batch System Working Group is a collective of dedicated batch system maintainers focused on advancing support for batch workloads in cloud-native environments.
+
+## Communications
+
+- Meeting Schedule: Every other Monday at 8am PDT/PST
+- [Meeting Invite](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=aTBka2F2aWt2ZTM0aTZuaG40MXRhdHM2dHNfMjAyMzA5MTFUMTUwMDAwWiBjXzY1MjRkNjA2OWI0YjczZDY1NGE2ZGFkYmFjNmQzMWRhMmU3NzZkOWNhMGRkZGY4OGFiMTJlMjZiODc1NzBhODJAZw&tmsrc=c_6524d6069b4b73d654a6dadbac6d31da2e776d9ca0dddf88ab12e26b87570a82%40group.calendar.google.com&scp=ALL)
+- Mailing list: cncf-wg-bsi@googlegroups.com 
+- Slack channel:  https://cloud-native.slack.com/archives/C02Q5DFF3MM 


### PR DESCRIPTION
I wanted the initial page of the BSI working group to have a bit more info in it.  We can flesh it out more later, but at least this is a start.