### PR TITLE
fix: Correct link for mailing list in landing page

### DIFF
--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -26,7 +26,7 @@ technical domains.
 - [Community events](https://community.cncf.io/tag-runtime/)
 - Slack channel: [#tag-runtime](https://cloud-native.slack.com/messages/CPBE97SMU)
     - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
-- [Mailing list](https://lists.cncf.io/g/cncf-runtime/topics)
+- [Mailing list](https://lists.cncf.io/g/cncf-tag-runtime)
 
 <p class="mt-5"><img src="/images/man-using-laptop.jpg" alt="Man working on computer"></p>
 

--- a/website/content/ja/_index.md
+++ b/website/content/ja/_index.md
@@ -25,7 +25,7 @@ description: "TEST"
 - [コミュニティイベント](https://community.cncf.io/tag-runtime/)
 - Slackチャンネル: [#tag-runtime](https://cloud-native.slack.com/messages/CPBE97SMU)
     - [CNCF Slackにご自身を招待する](https://slack.cncf.io/)
-- [メーリングリスト](https://lists.cncf.io/g/cncf-runtime/topics)
+- [メーリングリスト](https://lists.cncf.io/g/cncf-tag-runtime)
 
 <p class="mt-5"><img src="/images/man-using-laptop.jpg" alt="Man working on computer"></p>
 


### PR DESCRIPTION
Fixes #195 

---

This fixes the broken link in the website landing page for the mailing lists: I found the correct mailing list link in this repo's `README.md`

---

Before this change:

```
❯ rg https://lists.cncf.io/g/cncf-runtime/topics
website/content/en/_index.md
29:- [Mailing list](https://lists.cncf.io/g/cncf-runtime/topics)

website/content/ja/_index.md
28:- [メーリングリスト](https://lists.cncf.io/g/cncf-runtime/topics)
```

After this change:

```
❯ rg https://lists.cncf.io/g/cncf-runtime/topics
```