### PR TITLE
Fix typos in CNAI website

### DIFF
--- a/wgs/cnai/charter/index.md
+++ b/wgs/cnai/charter/index.md
@@ -123,7 +123,7 @@ We will promote the group's achievements and gather feedback to enhance our impa
 
 # Alignment with other Tags
 
-To better understand and utilize the the impact of AI on the cloud-native eco-system, it is within the scope of the AI WG to reach out and align with the rest of the TAGs to make sure there is topic coverage and to implement an AI strategy across the ecosystem in tandem with the rest of the TAGs and working groups.
+To better understand and utilize the impact of AI on the cloud-native ecosystem, it is within the scope of the AI WG to reach out and align with the rest of the TAGs to make sure there is topic coverage and to implement an AI strategy across the ecosystem in tandem with the rest of the TAGs and working groups.
 
 # Tracking our Work
 

--- a/wgs/cnai/onboarding/index.md
+++ b/wgs/cnai/onboarding/index.md
@@ -33,7 +33,7 @@ If you found an area you are interested in,  feel free to bring it up.  There is
 * Set a tentative target date and deliverables.
 * Gather critical mass (Some things could be done solo)
 * Execute (hopefully with critical mass).
-* Share the outcome (community, Kubecon, other conferences, etc)
+* Share the outcome (community, KubeCon + CloudNativeCon, other conferences, etc)
 
 As a group we are trying to converge into a roadmap to produce useful artifacts for the community. Here is a proposal on roadmap/approach:
 

--- a/wgs/cnai/onboarding/index.md
+++ b/wgs/cnai/onboarding/index.md
@@ -33,7 +33,7 @@ If you found an area you are interested in,  feel free to bring it up.  There is
 * Set a tentative target date and deliverables.
 * Gather critical mass (Some things could be done solo)
 * Execute (hopefully with critical mass).
-* Share the outcome (community, kubecon, other conferences, etc)
+* Share the outcome (community, Kubecon, other conferences, etc)
 
 As a group we are trying to converge into a roadmap to produce useful artifacts for the community. Here is a proposal on roadmap/approach:
 
@@ -51,7 +51,7 @@ As a group we are trying to converge into a roadmap to produce useful artifacts 
 
 ## Step 6: Join the Twice Monthly Online Meetings
 
-Last but not least, do try to attend the twice montly meetings to stay connected with the group, engage in discussions, and contribute to existing or new projects/initiatives. Add the CNCF calendar for call details which also includes the date/time for AI working group meetings: [https://www.cncf.io/calendar/](https://www.cncf.io/calendar/).
+Last but not least, do try to attend the twice monthly meetings to stay connected with the group, engage in discussions, and contribute to existing or new projects/initiatives. Add the CNCF calendar for call details which also includes the date/time for AI working group meetings: [https://www.cncf.io/calendar/](https://www.cncf.io/calendar/).
 
 We currently meet the 2nd and 4th Friday at 8 am pst.
 
@@ -59,4 +59,4 @@ Join Slack at https://cloud-native.slack.com then channel #wg-artificial-intelli
 
 ## Step 7: Join the mailing list
 
-Most of the discussion is happening on a slack, but the mailing list is an additional veneue where asynchronus discussions can happen as well. You can subscribe [here](https://lists.cncf.io/g/wg-artificial-intelligence).
+Most of the discussion is happening on a slack, but the mailing list is an additional venue where asynchronous discussions can happen as well. You can subscribe [here](https://lists.cncf.io/g/wg-artificial-intelligence).


### PR DESCRIPTION
Fixing a few typos on the onboarding and charter pages for CNAI