### PR TITLE
Adding otel-genai-instrumentation as a related SIG

### DIFF
--- a/wgs/cnai/charter/index.md
+++ b/wgs/cnai/charter/index.md
@@ -150,6 +150,7 @@ OPEA offers reference architectures for building LLM and Generative AI applicati
 * wg-batch (Kubernetes)  
 * wg-serving (Kubernetes)  
 * Accelerator-Management (Kubernetes)
+* otel-genai-instrumentation (OpenTelemetry)
 
 # TOC Liaisons
 


### PR DESCRIPTION
There are lot of works has been done with OpenTelemetry GenAI SIG include the following:
- Semantic convention for GenAI
- Instrumentation for GenAI, including OpenAI, Google GenAI, VertexAI etc.
- Blog for GenAI Observability

GenAI Observability is a very important part for this wg for trust/transparent AI.